### PR TITLE
fix: taking from fallback source

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,16 +13,13 @@ linters-settings:
 linters:
   disable-all: true
   enable:
-    - deadcode    #Default linter
     - errcheck    #Default linter
     - gosimple    #Default linter
     - govet       #Default linter
     - ineffassign #Default linter
     - staticcheck #Default linter
-    - structcheck #Default linter
     - typecheck   #Default linter
     - unused      #Default linter
-    - varcheck    #Default linter
     - gofmt
     - gci
     - goimports

--- a/script/compiler/compiler.go
+++ b/script/compiler/compiler.go
@@ -6,11 +6,10 @@ import (
 	"strings"
 
 	"github.com/antlr/antlr4/runtime/Go/antlr"
+	ledger "github.com/numary/ledger/pkg/core"
 	"github.com/numary/machine/core"
 	"github.com/numary/machine/script/parser"
 	"github.com/numary/machine/vm/program"
-
-	ledger "github.com/numary/ledger/pkg/core"
 )
 
 type parseVisitor struct {

--- a/script/compiler/compiler_test.go
+++ b/script/compiler/compiler_test.go
@@ -9,10 +9,9 @@ import (
 	"strings"
 	"testing"
 
+	ledger "github.com/numary/ledger/pkg/core"
 	"github.com/numary/machine/core"
 	"github.com/numary/machine/vm/program"
-
-	ledger "github.com/numary/ledger/pkg/core"
 )
 
 type CaseResult struct {

--- a/script/compiler/source.go
+++ b/script/compiler/source.go
@@ -87,7 +87,7 @@ func (p *parseVisitor) TakeFromSource(fallback *FallbackAccount, push_asset func
 		if err != nil {
 			return err
 		}
-		p.AppendInstruction(program.OP_TAKE_ALL)
+		p.AppendInstruction(program.OP_TAKE_ALWAYS)
 		err = p.PushInteger(*core.NewNumber(2))
 		if err != nil {
 			return err

--- a/vm/program/instructions.go
+++ b/vm/program/instructions.go
@@ -14,8 +14,9 @@ const (
 	OP_MONETARY_ADD     // <monetary> <monetary> => <monetary>   // panics if not same asset
 	OP_MAKE_ALLOTMENT   // <portion>*N <int N> => <allotment(N)>
 	OP_TAKE_ALL         // <source: account> <overdraft: monetary> => <funding>
+	OP_TAKE_ALWAYS      // <source: account> <monetary> => <funding>   // takes amount from account unconditionally
 	OP_TAKE             // <funding> <monetary> => <remaining: funding> <taken: funding> // fails with EXIT_INSUFFICIENT_FUNDS if not enough
-	OP_TAKE_MAX         // <funding> <monetary> => <missing: monetary> <remaining: funding> <taken: funding> // (doesn't fail on insufficient funds)
+	OP_TAKE_MAX         // <funding> <monetary> => <missing: monetary> <remaining: funding> <taken: funding> // Doesn't fail on insufficient funds. Either missing or remaining is zero.
 	OP_FUNDING_ASSEMBLE // <funding>*N <int N> => <funding> (first has highest priority)
 	OP_FUNDING_SUM      // <funding> => <funding> <sum: monetary>
 	OP_FUNDING_REVERSE  // <funding> => <funding>

--- a/vm/program/instructions.go
+++ b/vm/program/instructions.go
@@ -54,6 +54,8 @@ func OpcodeName(op byte) string {
 		return "OP_MAKE_ALLOTMENT"
 	case OP_TAKE_ALL:
 		return "OP_TAKE_ALL"
+	case OP_TAKE_ALWAYS:
+		return "OP_TAKE_ALWAYS"
 	case OP_TAKE:
 		return "OP_TAKE"
 	case OP_TAKE_MAX:


### PR DESCRIPTION
Fixes taking a monetary amount from fallback sources (unbounded overdraft & world), so that it ignores the actual balance and works correctly with successive sends.