### PR TITLE
fix: allow 0 and 100 inclusive in portions

### DIFF
--- a/core/allotment.go
+++ b/core/allotment.go
@@ -32,9 +32,6 @@ func NewAllotment(portions []Portion) (*Allotment, error) {
 	if total.Cmp(big.NewRat(1, 1)) == 1 {
 		return nil, errors.New("sum of portions exceeded 100%")
 	}
-	if remainingIdx != nil && total.Cmp(big.NewRat(1, 1)) == 1 {
-		return nil, errors.New("portions include 'remaining' but sum is more than 100%")
-	}
 	if remainingIdx != nil {
 		remaining := big.NewRat(1, 1)
 		remaining.Sub(remaining, total)

--- a/core/allotment.go
+++ b/core/allotment.go
@@ -32,8 +32,8 @@ func NewAllotment(portions []Portion) (*Allotment, error) {
 	if total.Cmp(big.NewRat(1, 1)) == 1 {
 		return nil, errors.New("sum of portions exceeded 100%")
 	}
-	if remainingIdx != nil && total.Cmp(big.NewRat(1, 1)) != -1 {
-		return nil, errors.New("portions include 'remaining' but sum is 100% or more")
+	if remainingIdx != nil && total.Cmp(big.NewRat(1, 1)) == 1 {
+		return nil, errors.New("portions include 'remaining' but sum is more than 100%")
 	}
 	if remainingIdx != nil {
 		remaining := big.NewRat(1, 1)

--- a/core/allotment_test.go
+++ b/core/allotment_test.go
@@ -28,6 +28,27 @@ func TestAllocate(t *testing.T) {
 	}
 }
 
+func TestAllocateEmptyRemainder(t *testing.T) {
+	allotment, err := NewAllotment([]Portion{
+		{Specific: big.NewRat(1, 2)},
+		{Specific: big.NewRat(1, 2)},
+		{Remaining: true},
+	})
+	require.NoError(t, err)
+
+	parts := allotment.Allocate(NewMonetaryInt(15))
+	expectedParts := []*MonetaryInt{NewMonetaryInt(8), NewMonetaryInt(7), NewMonetaryInt(0)}
+	if len(parts) != len(expectedParts) {
+		t.Fatalf("unexpected output %v != %v", parts, expectedParts)
+	}
+	for i := range parts {
+		if !parts[i].Equal(expectedParts[i]) {
+			t.Fatalf("unexpected output %v != %v", parts, expectedParts)
+		}
+	}
+
+}
+
 func TestInvalidAllotments(t *testing.T) {
 	_, err := NewAllotment([]Portion{
 		{Remaining: true},
@@ -42,11 +63,4 @@ func TestInvalidAllotments(t *testing.T) {
 		{Specific: big.NewRat(1, 2)},
 	})
 	assert.Errorf(t, err, "allowed more than 100%")
-
-	_, err = NewAllotment([]Portion{
-		{Specific: big.NewRat(1, 2)},
-		{Specific: big.NewRat(1, 2)},
-		{Remaining: true},
-	})
-	assert.Errorf(t, err, "allowed remaining but already at 100%")
 }

--- a/core/portion.go
+++ b/core/portion.go
@@ -22,8 +22,8 @@ func NewPortionRemaining() Portion {
 }
 
 func NewPortionSpecific(r big.Rat) (*Portion, error) {
-	if r.Cmp(big.NewRat(0, 1)) != 1 || r.Cmp(big.NewRat(1, 1)) != -1 {
-		return nil, errors.New("portion must be between 0% and 100% exclusive")
+	if r.Cmp(big.NewRat(0, 1)) == -1 || r.Cmp(big.NewRat(1, 1)) == 1 {
+		return nil, errors.New("portion must be between 0% and 100% inclusive")
 	}
 	return &Portion{
 		Remaining: false,
@@ -38,8 +38,8 @@ func ValidatePortionSpecific(p Portion) error {
 	if p.Specific == nil {
 		return errors.New("specific portion should not be nil")
 	}
-	if p.Specific.Cmp(big.NewRat(0, 1)) != 1 || p.Specific.Cmp(big.NewRat(1, 1)) != -1 {
-		return errors.New("specific portion must be between 0% and 100% exclusive")
+	if p.Specific.Cmp(big.NewRat(0, 1)) == -1 || p.Specific.Cmp(big.NewRat(1, 1)) == 1 {
+		return errors.New("specific portion must be between 0% and 100% inclusive")
 	}
 	return nil
 }

--- a/core/portion_test.go
+++ b/core/portion_test.go
@@ -1,17 +1,120 @@
 package core
 
 import (
+	"math/big"
 	"strings"
 	"testing"
 )
 
-func TestNotBetween0And1(t *testing.T) {
-	_, err := ParsePortionSpecific("3/2")
-	if err == nil {
-		t.Fatal("should have errored")
+func TestBetween0And1Inclusive(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    *big.Rat
+		wantErr bool
+	}{
+		{
+			in:   "0%",
+			want: big.NewRat(0, 1),
+		},
+		{
+			in:   "0.0%",
+			want: big.NewRat(0, 1),
+		},
+		{
+			in:   "0/1",
+			want: big.NewRat(0, 1),
+		},
+		{
+			in:   "0/25",
+			want: big.NewRat(0, 1),
+		},
+		{
+			in:   "0/100",
+			want: big.NewRat(0, 1),
+		},
+		{
+			in:   "1%",
+			want: big.NewRat(1, 100),
+		},
+		{
+			in:   "1/100",
+			want: big.NewRat(1, 100),
+		},
+		{
+			in:   "10/1000",
+			want: big.NewRat(1, 100),
+		},
+		{
+			in:   "50/100",
+			want: big.NewRat(50, 100),
+		},
+		{
+			in:   "50%",
+			want: big.NewRat(50, 100),
+		},
+		{
+			in:   "50.0%",
+			want: big.NewRat(50, 100),
+		},
+		{
+			in:   "1/1",
+			want: big.NewRat(1, 1),
+		},
+		{
+			in:   "100/100",
+			want: big.NewRat(1, 1),
+		},
+		{
+			in:   "100.0%",
+			want: big.NewRat(1, 1),
+		},
+		{
+			in:   "100%",
+			want: big.NewRat(1, 1),
+		},
+		// Now for the failures. We don't check negative numbers in this test because
+		// those are a parsing failure, not a range failure.
+		{
+			in:      "100.1%",
+			wantErr: true,
+		},
+		{
+			in:      "101%",
+			wantErr: true,
+		},
+		{
+			in:      "101/100",
+			wantErr: true,
+		},
+		{
+			in:      "2/1",
+			wantErr: true,
+		},
+		{
+			in:      "3/2",
+			wantErr: true,
+		},
 	}
-	if !strings.Contains(err.Error(), "between") {
-		t.Fatal("wrong error")
+
+	for _, test := range tests {
+		t.Run(test.in, func(t *testing.T) {
+			got, err := ParsePortionSpecific(test.in)
+			if test.wantErr {
+				if err == nil {
+					t.Fatal("should have errored")
+				}
+				if !strings.Contains(err.Error(), "between") {
+					t.Fatal("wrong error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParsePortionSpecific(%q): %v", test.in, err)
+			}
+			if test.want.Cmp(got.Specific) != 0 {
+				t.Fatalf("ParsePortionSpecific(%q) = %q, want %q", test.in, got, test.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
This PR updates portions to accept both 0% and 100% as valid values, and adds a few tests to cover the new cases.
